### PR TITLE
Permit creation of domain records

### DIFF
--- a/index.js
+++ b/index.js
@@ -1035,7 +1035,7 @@ var DigitalOcean = PromiseObject.create({
 	 * 
 	 * This method creates a new domain name with an A record for the specified [ip_address].
 	 */
-	domainNew: function($deferred, name, body, raw) {
+	domainRecordNew: function($deferred, name, body, raw) {
 		$deferred.resolve(this._request({
 			params: {
 				domain_name: Joi.string().required()


### PR DESCRIPTION
I think there's a typo... there are two `domainNew` implementations and no `domainRecordNew` implementation. From the looks of it, the second implementation should be called `domainRecordNew`. This pull request fixes that.
